### PR TITLE
Fix formatting for android studio

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -85,9 +85,13 @@ dependencies {
     compile 'com.github.chrisbanes.photoview:library:1.2.4'
     //
     compile 'com.android.support:support-annotations:' + rootProject.ext.supportVersion
+    //
     compile 'com.android.support:recyclerview-v7:' + rootProject.ext.supportVersion
+    //
     compile 'com.android.support:design:' + rootProject.ext.supportVersion
+    //
     compile 'com.android.support:appcompat-v7:' + rootProject.ext.supportVersion
+    //
     compile 'com.android.support:support-vector-drawable:' + rootProject.ext.supportVersion
     //
     compile 'org.greenrobot:eventbus:3.0.0'


### PR DESCRIPTION
Android studio keeps putting those lines into 1, making the gradle sync not work, the commented ines should avoid this